### PR TITLE
Fix cross-platform shellcheck install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install shellcheck
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            choco install -y shellcheck
+          fi
       - name: Lint Shell Scripts
         run: shellcheck tests/*.sh
       - name: Build


### PR DESCRIPTION
## Summary
- fix shellcheck installation in CI for macOS and Windows

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_6843efd69c688324bf6b31cc8e8eff60